### PR TITLE
fix: plain.jar 생성하지 않도록 하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,10 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
+// plain.jar 생성하지 않게 하기
+jar {
+    enabled = false
+}
 
 tasks.named('test') {
     useJUnitPlatform()


### PR DESCRIPTION
- github actions + aws eb 배포 시, .jar 를 실행하는 코드를 이용할 것이기 때문